### PR TITLE
Update meta schema to match new standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ from `requirements.txt`, then run:
 python -m tests
 ```
 
-#### Running tests on the remote schemas
+Tests can also run against a remote dynamodb schema registry but by default this is
+disabled.
 
-Tests can run against a remote dynamodb schema registry but by default this is
-disabled. See `python -m tests --help` to enable them.
+See `python -m tests --help` to enable remote schema registry tests and for all other options.

--- a/meta-schema
+++ b/meta-schema
@@ -280,16 +280,84 @@
                                     "int",
                                     "long",
                                     "float",
-                                    "double"
+                                    "decimal",
+                                    "bool"
                                 ]
+                            },
+                            "type": {
+                                "if": {
+                                    "enum": [
+                                        "array",
+                                        "boolean",
+                                        "null",
+                                        "object"
+                                    ]
+                                },
+                                "then": false,
+                                "else": true
                             }
                         },
                         "required": [
                             "type"
-                        ]
+                        ],
+                        "dependencies": {
+                            "mvDType": {
+                                "$ref": "#/definitions/typeCombinations"
+                            }
+                        }
                     }
                 }
             }
+        },
+        "typeCombinations": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "mvDType": {
+                            "enum": [
+                                "int",
+                                "long",
+                                "float",
+                                "decimal"
+                            ]
+                        },
+                        "type": {
+                            "const": "string"
+                        }
+                    },
+                    "required": [
+                        "mvDType",
+                        "type"
+                    ]
+                },
+                {
+                    "properties": {
+                        "mvDType": {
+                            "const": "bool"
+                        },
+                        "type": {
+                            "const": "string"
+                        },
+                        "enum": {
+                            "enum": [
+                                [
+                                    "0",
+                                    "1"
+                                ],
+                                [
+                                    "1",
+                                    "0"
+                                ]
+                            ]
+                        }
+                    },
+                    "required": [
+                        "mvDType",
+                        "type",
+                        "enum"
+                    ]
+                }
+            ]
         },
         "schema": {
             "allOf": [


### PR DESCRIPTION
Invalidated schemas:
- university-of-cambridge/downtime_monitoring/downtime_schema.json
  - uses `boolean` type.
- university-of-cambridge/scrap_and_rework_monitoring/block_message.json
  - uses `array` and `object` types